### PR TITLE
Add removeMany and keepOnly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 elm-stuff/
 elm.js
 test/test.js
+*~

--- a/src/Dict/Extra.elm
+++ b/src/Dict/Extra.elm
@@ -43,11 +43,11 @@ removeWhen pred dict =
     Dict.filter (\c v -> not (pred c v)) dict
 
 
-{-| Keep a key-value pair exactly if its key does not appear in the list.
+{-| Keep a key-value pair exactly if its key does not appear in the set.
 -}
-removeMany : List comparable -> Dict comparable v -> Dict comparable v
-removeMany list dict =
-    List.foldl Dict.remove dict list
+removeMany : Set comparable -> Dict comparable v -> Dict comparable v
+removeMany set dict =
+    Set.foldl Dict.remove dict set
 
 
 {-| Keep a key-value pair exactly if its key appears in the set.

--- a/src/Dict/Extra.elm
+++ b/src/Dict/Extra.elm
@@ -53,5 +53,5 @@ removeMany set dict =
 {-| Keep a key-value pair exactly if its key appears in the set.
 -}
 keepOnly : Set comparable -> Dict comparable v -> Dict comparable v
-keepOnly set =
-    Dict.filter (\k _ -> Set.member k set)
+keepOnly set dict =
+    Set.foldl (\k acc -> Maybe.withDefault acc (Maybe.map (\v -> Dict.insert k v acc) (Dict.get k dict))) Dict.empty set

--- a/src/Dict/Extra.elm
+++ b/src/Dict/Extra.elm
@@ -43,11 +43,11 @@ removeWhen pred dict =
     Dict.filter (\c v -> not (pred c v)) dict
 
 
-{-| Keep a key-value pair exactly if its key does not appear in the set.
+{-| Keep a key-value pair exactly if its key does not appear in the list.
 -}
-removeMany : Set comparable -> Dict comparable v -> Dict comparable v
-removeMany set dict =
-    Set.foldl Dict.remove dict set
+removeMany : List comparable -> Dict comparable v -> Dict comparable v
+removeMany list dict =
+    List.foldl Dict.remove dict list
 
 
 {-| Keep a key-value pair exactly if its key appears in the set.

--- a/src/Dict/Extra.elm
+++ b/src/Dict/Extra.elm
@@ -1,18 +1,18 @@
-module Dict.Extra exposing (groupBy, removeWhen)
+module Dict.Extra exposing (groupBy, removeWhen, removeMany, keepOnly)
 
-{-| Convenience functions for working with Dict
+{-| Convenience functions for working with `Dict`
 
 # List operations
 @docs groupBy
 
 # Manipulation
-@docs removeWhen
+@docs removeWhen, removeMany, keepOnly
 -}
 
 import Dict exposing (Dict)
+import Set exposing (Set)
 
-
-{-| Takes a key-fn and a list, creates a Dict which maps the key returned from key-fn, to a list of matching elements.
+{-| Takes a key-fn and a list, creates a `Dict` which maps the key returned from key-fn, to a list of matching elements.
 
     mary = {groupId: 1, name: "Mary"}
     jack = {groupId: 2, name: "Jack"}
@@ -33,11 +33,25 @@ groupBy keyfn list =
         list
 
 
-{-| Keep elements which fails to satisfy the predicate.
-    This is functionaly equivalent to `Dict.filter (not << predicate) dict`.
+{-| Keep elements which fail to satisfy the predicate.
+    This is functionally equivalent to `Dict.filter (not << predicate) dict`.
 
     removeWhen (\c v -> v == 1) Dict.fromList [("Mary", 1), ("Jack", 2), ("Jill", 1)] == Dict.fromList [("Jack", 2)]
 -}
 removeWhen : (comparable -> v -> Bool) -> Dict comparable v -> Dict comparable v
 removeWhen pred dict =
     Dict.filter (\c v -> not (pred c v)) dict
+
+
+{-| Keep a key-value pair exactly if its key does not appear in the set.
+-}
+removeMany : Set comparable -> Dict comparable v -> Dict comparable v
+removeMany set dict =
+    Set.foldl Dict.remove dict set
+
+
+{-| Keep a key-value pair exactly if its key appears in the set.
+-}
+keepOnly : Set comparable -> Dict comparable v -> Dict comparable v
+keepOnly set =
+    Dict.filter (\k _ -> Set.member k set)

--- a/test/Test.elm
+++ b/test/Test.elm
@@ -3,6 +3,7 @@ module Test exposing (..)
 import ElmTest exposing (..)
 import Dict
 import Dict.Extra exposing (..)
+import Set
 
 
 main : Program Never
@@ -15,6 +16,8 @@ tests =
     suite "Dict tests"
         [ groupByTests
         , removeWhenTests
+        , removeManyTests
+        , keepOnlyTests
         ]
 
 
@@ -62,4 +65,30 @@ removeWhenTests =
         [ test "example"
             <| assertEqual (Dict.fromList [ ( "Jack", 2 ) ])
             <| removeWhen (\_ v -> v == 1) (Dict.fromList [ ( "Mary", 1 ), ( "Jack", 2 ), ( "Jill", 1 ) ])
+        ]
+
+
+
+-- removeMany
+
+
+removeManyTests : Test
+removeManyTests =
+    suite "removeMany"
+        [ test "example"
+            <| assertEqual (Dict.fromList [ ( "Jack", 2 ) ])
+            <| removeMany [ "Mary", "Jill" ] (Dict.fromList [ ( "Mary", 1 ), ( "Jack", 2 ), ( "Jill", 1 ) ])
+        ]
+
+
+
+-- keepOnly
+
+
+keepOnlyTests : Test
+keepOnlyTests =
+    suite "keepOnly"
+        [ test "example"
+            <| assertEqual (Dict.fromList [ ( "Jack", 2 ), ( "Jill", 1 ) ])
+            <| keepOnly (Set.fromList [ "Jack", "Jill" ]) (Dict.fromList [ ( "Mary", 1 ), ( "Jack", 2 ), ( "Jill", 1 ) ])
         ]

--- a/test/Test.elm
+++ b/test/Test.elm
@@ -77,7 +77,7 @@ removeManyTests =
     suite "removeMany"
         [ test "example"
             <| assertEqual (Dict.fromList [ ( "Jack", 2 ) ])
-            <| removeMany [ "Mary", "Jill" ] (Dict.fromList [ ( "Mary", 1 ), ( "Jack", 2 ), ( "Jill", 1 ) ])
+            <| removeMany (Set.fromList [ "Mary", "Jill" ]) (Dict.fromList [ ( "Mary", 1 ), ( "Jack", 2 ), ( "Jill", 1 ) ])
         ]
 
 


### PR DESCRIPTION
These are variants of `Dict.diff` and `Dict.intersect` that I find to present a more useful API, given that in `Dict.diff` and `Dict.intersect` one argument is a dictionary whose values are irrelevant. See https://github.com/elm-lang/core/issues/518#issuecomment-192820149.

Also, `removeMany` is a very natural generalisation of the existing function `Dict.remove`.