### PR TITLE
Add fromListBy, to create Dicts from Lists and a key function

### DIFF
--- a/src/Dict/Extra.elm
+++ b/src/Dict/Extra.elm
@@ -35,7 +35,7 @@ groupBy keyfn list =
 
 {-| Create a dictionary from a list of values, by passing a function that can get a key from any such value. This can, for instance, be useful when constructing Dicts from a List of records with `id` fields:
 
-    fromListBy .id [{id=1, name="Jack"}, {id=2, name="Jill"}] == Dict.fromList [(1, { id = 1, name = "Jack" }), (2, { id = 2, name = "Jill" })]
+    fromListBy .id [{ id=1, name="Jack" }, { id=2, name="Jill" }] == Dict.fromList [(1, { id=1, name="Jack" }), (2, { id=2, name="Jill" })]
 -}
 fromListBy : (a -> comparable) -> List a -> Dict comparable a
 fromListBy keyfn xs =

--- a/src/Dict/Extra.elm
+++ b/src/Dict/Extra.elm
@@ -1,9 +1,9 @@
-module Dict.Extra exposing (groupBy, removeWhen, removeMany, keepOnly)
+module Dict.Extra exposing (groupBy, fromListBy, removeWhen, removeMany, keepOnly)
 
 {-| Convenience functions for working with `Dict`
 
 # List operations
-@docs groupBy
+@docs groupBy, fromListBy
 
 # Manipulation
 @docs removeWhen, removeMany, keepOnly
@@ -31,6 +31,15 @@ groupBy keyfn list =
         )
         Dict.empty
         list
+
+
+{-| Create a dictionary from a list of values, by passing a function that can get a key from any such value. This can, for instance, be useful when constructing Dicts from a List of records with `id` fields:
+
+    fromListBy .id [{id=1, name="Jack"}, {id=2, name="Jill"}] == Dict.fromList [(1, { id = 1, name = "Jack" }), (2, { id = 2, name = "Jill" })]
+-}
+fromListBy : (a -> comparable) -> List a -> Dict comparable a
+fromListBy keyfn xs =
+    List.foldl (\x acc -> Dict.insert (keyfn x) x acc) Dict.empty xs
 
 
 {-| Keep elements which fail to satisfy the predicate.


### PR DESCRIPTION
This adds a nice little function I've found to particularly be useful when creating a Dict of records by their `id` property, or similar – see the example in the docs :)