### PR TITLE
Add filterMap

### DIFF
--- a/src/Dict/Extra.elm
+++ b/src/Dict/Extra.elm
@@ -6,6 +6,7 @@ module Dict.Extra
         , removeMany
         , keepOnly
         , mapKeys
+        , filterMap
         )
 
 {-| Convenience functions for working with `Dict`
@@ -14,7 +15,7 @@ module Dict.Extra
 @docs groupBy, fromListBy
 
 # Manipulation
-@docs removeWhen, removeMany, keepOnly, mapKeys
+@docs removeWhen, removeMany, keepOnly, mapKeys, filterMap
 -}
 
 import Dict exposing (Dict)
@@ -93,3 +94,24 @@ mapKeys keyMapper dict =
             Dict.insert (keyMapper key) value d
     in
         Dict.foldl addKey Dict.empty dict
+
+
+{-| Apply a function that may or may not succeed to all entries in a dictionary,
+but only keep the successes.
+-}
+filterMap :
+    (comparable -> a -> Maybe b)
+    -> Dict comparable a
+    -> Dict comparable b
+filterMap f dict =
+    Dict.foldl
+        (\k v ->
+            case f k v of
+                Just newVal ->
+                    Dict.insert k newVal
+
+                Nothing ->
+                    identity
+        )
+        Dict.empty
+        dict

--- a/src/Dict/Extra.elm
+++ b/src/Dict/Extra.elm
@@ -98,6 +98,21 @@ mapKeys keyMapper dict =
 
 {-| Apply a function that may or may not succeed to all entries in a dictionary,
 but only keep the successes.
+
+    isTeen : Int -> String -> Maybe String
+    isTeen n a =
+        if 13 <= n && n <= 19 then
+            Just <| String.toUpper a
+        else
+            Nothing
+
+    Dict.fromList
+        [ ( 5, "Jack" )
+        , ( 15, "Jill" )
+        , ( 20, "Jones" )
+        ]
+        |> filterMap isTeen
+        == Dict.singleton 15 "JILL"
 -}
 filterMap :
     (comparable -> a -> Maybe b)

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,8 +1,7 @@
 port module Main exposing (main, emit)
 
 import Test.Runner.Node exposing (run, TestProgram)
-import Test exposing (Test, describe, test, fuzz, fuzz2)
-import Fuzz exposing (Fuzzer, intRange)
+import Test exposing (Test, describe, test)
 import Expect
 import Json.Encode exposing (Value)
 import Dict exposing (Dict)

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -5,7 +5,7 @@ import Test exposing (Test, describe, test, fuzz, fuzz2)
 import Fuzz exposing (Fuzzer, intRange)
 import Expect
 import Json.Encode exposing (Value)
-import Dict
+import Dict exposing (Dict)
 import Dict.Extra exposing (..)
 import Set
 
@@ -136,4 +136,34 @@ mapKeysTests =
             \() ->
                 mapKeys ((+) 1) (Dict.fromList [ ( 1, "Jack" ), ( 2, "Jill" ) ])
                     |> Expect.equal (Dict.fromList [ ( 2, "Jack" ), ( 3, "Jill" ) ])
+        ]
+
+
+
+-- filterMap
+
+
+filterMapTests : Test
+filterMapTests =
+    describe "filterMap"
+        [ test "example" <|
+            \() ->
+                let
+                    isTeen : Int -> String -> Maybe String
+                    isTeen n a =
+                        if 13 <= n && n <= 19 then
+                            Just <| String.toUpper a
+                        else
+                            Nothing
+
+                    inputDict : Dict Int String
+                    inputDict =
+                        Dict.fromList
+                            [ ( 5, "Jack" )
+                            , ( 15, "Jill" )
+                            , ( 20, "Jones" )
+                            ]
+                in
+                    filterMap isTeen inputDict
+                        |> Expect.equalDicts (Dict.singleton 15 "JILL")
         ]


### PR DESCRIPTION
https://elmlang.slack.com/archives/C192T0Q1E/p1490987643920459

Apparently there is no `Dict.filterMap` anywhere. Makes sense to have it.