### PR TITLE
Allow key-mapper to convert to a different type of comparable

### DIFF
--- a/src/Dict/Extra.elm
+++ b/src/Dict/Extra.elm
@@ -115,7 +115,7 @@ keepOnly set dict =
     == Dict.fromList [(6, "Jack"), (11, "Jill")]
 
 -}
-mapKeys : (comparable -> comparable) -> Dict comparable v -> Dict comparable v
+mapKeys : (comparable -> comparable1) -> Dict comparable v -> Dict comparable1 v
 mapKeys keyMapper dict =
     Dict.foldl
         (\k v acc ->

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -137,6 +137,10 @@ mapKeysTests =
             \() ->
                 mapKeys ((+) 1) (Dict.fromList [ ( 1, "Jack" ), ( 2, "Jill" ) ])
                     |> Expect.equal (Dict.fromList [ ( 2, "Jack" ), ( 3, "Jill" ) ])
+        , test "change type" <|
+            \() ->
+                mapKeys toString (Dict.fromList [ ( 1, "Jack" ), ( 2, "Jill" ) ])
+                    |> Expect.equal (Dict.fromList [ ( "1", "Jack" ), ( "2", "Jill" ) ])
         ]
 
 


### PR DESCRIPTION
Kind of surprised me that it only allows `comparable -> comparable`.