### PR TITLE
Add insertWith, fromListWith, and fromListWithBy, for dealing with duplicate keys

### DIFF
--- a/src/Dict/Extra.elm
+++ b/src/Dict/Extra.elm
@@ -2,6 +2,7 @@ module Dict.Extra
     exposing
         ( groupBy
         , fromListBy
+        , fromListWith
         , removeWhen
         , removeMany
         , insertWith
@@ -17,7 +18,7 @@ module Dict.Extra
 
 # List operations
 
-@docs groupBy, fromListBy
+@docs groupBy, fromListBy, fromListWith
 
 
 # Manipulation
@@ -65,6 +66,25 @@ fromListBy : (a -> comparable) -> List a -> Dict comparable a
 fromListBy keyfn xs =
     List.foldl
         (\x acc -> Dict.insert (keyfn x) x acc)
+        Dict.empty
+        xs
+
+
+{-| Like `Dict.fromList`, but you provide a way to deal with
+duplicate keys. Create a dictionary from a list of pairs of keys and
+values, providing a function that is used to combine multiple values
+paired with the same key.
+
+    >>> fromListWith
+    ...     (\a b -> a ++ " " ++ b)
+    ...     [ ( "class", "menu" ), ( "width", "100%" ), ( "class", "big" ) ]
+    Dict.fromList [ ( "class", "menu big" ), ( "width", "100%" ) ]
+
+-}
+fromListWith : (a -> a -> a) -> List ( comparable, a ) -> Dict comparable a
+fromListWith combine xs =
+    List.foldl
+        (\( key, value ) acc -> insertWith combine key value acc)
         Dict.empty
         xs
 

--- a/src/Dict/Extra.elm
+++ b/src/Dict/Extra.elm
@@ -3,6 +3,7 @@ module Dict.Extra
         ( groupBy
         , fromListBy
         , fromListWith
+        , fromListWithBy
         , removeWhen
         , removeMany
         , insertWith
@@ -18,7 +19,7 @@ module Dict.Extra
 
 # List operations
 
-@docs groupBy, fromListBy, fromListWith
+@docs groupBy, fromListBy, fromListWith, fromListWithBy
 
 
 # Manipulation
@@ -85,6 +86,20 @@ fromListWith : (a -> a -> a) -> List ( comparable, a ) -> Dict comparable a
 fromListWith combine xs =
     List.foldl
         (\( key, value ) acc -> insertWith combine key value acc)
+        Dict.empty
+        xs
+
+
+{-| `fromListBy` and `fromListWith` rolled into one.
+
+    >>> fromListWithBy (\first second -> first) String.length [ "tree" , "apple" , "leaf" ]
+    Dict.fromList [ ( 4, "tree" ), ( 5, "apple" ) ]
+
+-}
+fromListWithBy : (a -> a -> a) -> (a -> comparable) -> List a -> Dict comparable a
+fromListWithBy combine keyfn xs =
+    List.foldl
+        (\x acc -> insertWith combine (keyfn x) x acc)
         Dict.empty
         xs
 

--- a/src/Dict/Extra.elm
+++ b/src/Dict/Extra.elm
@@ -4,6 +4,7 @@ module Dict.Extra
         , fromListBy
         , removeWhen
         , removeMany
+        , insertWith
         , keepOnly
         , mapKeys
         , filterMap
@@ -21,7 +22,7 @@ module Dict.Extra
 
 # Manipulation
 
-@docs removeWhen, removeMany, keepOnly, mapKeys, filterMap, invert
+@docs removeWhen, removeMany, keepOnly, insertWith, mapKeys, filterMap, invert
 
 
 # Find
@@ -92,6 +93,32 @@ removeWhen pred dict =
 removeMany : Set comparable -> Dict comparable v -> Dict comparable v
 removeMany set dict =
     Set.foldl Dict.remove dict set
+
+
+{-| Insert an element at the given key, providing a combining
+function that used in the case that there is already an
+element at that key. The combining function is called with
+original element and the new element as arguments and
+returns the element to be inserted.
+
+    >>> Dict.fromList [ ( "expenses", 38.25 ), ( "assets", 100.85 ) ]
+    ...     |> insertWith (+) "expenses" 2.50
+    ...     |> insertWith (+) "liabilities" -2.50
+    Dict.fromList [ ( "expenses", 40.75 ), ( "assets", 100.85 ), ( "liabilities", -2.50 ) ]
+
+-}
+insertWith : (v -> v -> v) -> comparable -> v -> Dict comparable v -> Dict comparable v
+insertWith combine key value dict =
+    let
+        with mbValue =
+            case mbValue of
+                Just oldValue ->
+                    Just <| combine oldValue value
+
+                Nothing ->
+                    Just value
+    in
+        Dict.update key with dict
 
 
 {-| Keep a key-value pair if its key appears in the set.

--- a/src/Dict/Extra.elm
+++ b/src/Dict/Extra.elm
@@ -2,11 +2,11 @@ module Dict.Extra
     exposing
         ( groupBy
         , fromListBy
-        , fromListWith
-        , fromListWithBy
+        , fromListDedupe
+        , fromListDedupeBy
         , removeWhen
         , removeMany
-        , insertWith
+        , insertDedupe
         , keepOnly
         , mapKeys
         , filterMap
@@ -19,12 +19,12 @@ module Dict.Extra
 
 # List operations
 
-@docs groupBy, fromListBy, fromListWith, fromListWithBy
+@docs groupBy, fromListBy, fromListDedupe, fromListDedupeBy
 
 
 # Manipulation
 
-@docs removeWhen, removeMany, keepOnly, insertWith, mapKeys, filterMap, invert
+@docs removeWhen, removeMany, keepOnly, insertDedupe, mapKeys, filterMap, invert
 
 
 # Find
@@ -76,30 +76,30 @@ duplicate keys. Create a dictionary from a list of pairs of keys and
 values, providing a function that is used to combine multiple values
 paired with the same key.
 
-    >>> fromListWith
+    >>> fromListDedupe
     ...     (\a b -> a ++ " " ++ b)
     ...     [ ( "class", "menu" ), ( "width", "100%" ), ( "class", "big" ) ]
     Dict.fromList [ ( "class", "menu big" ), ( "width", "100%" ) ]
 
 -}
-fromListWith : (a -> a -> a) -> List ( comparable, a ) -> Dict comparable a
-fromListWith combine xs =
+fromListDedupe : (a -> a -> a) -> List ( comparable, a ) -> Dict comparable a
+fromListDedupe combine xs =
     List.foldl
-        (\( key, value ) acc -> insertWith combine key value acc)
+        (\( key, value ) acc -> insertDedupe combine key value acc)
         Dict.empty
         xs
 
 
-{-| `fromListBy` and `fromListWith` rolled into one.
+{-| `fromListBy` and `fromListDedupe` rolled into one.
 
-    >>> fromListWithBy (\first second -> first) String.length [ "tree" , "apple" , "leaf" ]
+    >>> fromListDedupeBy (\first second -> first) String.length [ "tree" , "apple" , "leaf" ]
     Dict.fromList [ ( 4, "tree" ), ( 5, "apple" ) ]
 
 -}
-fromListWithBy : (a -> a -> a) -> (a -> comparable) -> List a -> Dict comparable a
-fromListWithBy combine keyfn xs =
+fromListDedupeBy : (a -> a -> a) -> (a -> comparable) -> List a -> Dict comparable a
+fromListDedupeBy combine keyfn xs =
     List.foldl
-        (\x acc -> insertWith combine (keyfn x) x acc)
+        (\x acc -> insertDedupe combine (keyfn x) x acc)
         Dict.empty
         xs
 
@@ -137,13 +137,13 @@ original element and the new element as arguments and
 returns the element to be inserted.
 
     >>> Dict.fromList [ ( "expenses", 38.25 ), ( "assets", 100.85 ) ]
-    ...     |> insertWith (+) "expenses" 2.50
-    ...     |> insertWith (+) "liabilities" -2.50
+    ...     |> insertDedupe (+) "expenses" 2.50
+    ...     |> insertDedupe (+) "liabilities" -2.50
     Dict.fromList [ ( "expenses", 40.75 ), ( "assets", 100.85 ), ( "liabilities", -2.50 ) ]
 
 -}
-insertWith : (v -> v -> v) -> comparable -> v -> Dict comparable v -> Dict comparable v
-insertWith combine key value dict =
+insertDedupe : (v -> v -> v) -> comparable -> v -> Dict comparable v -> Dict comparable v
+insertDedupe combine key value dict =
     let
         with mbValue =
             case mbValue of


### PR DESCRIPTION
These commits add three functions which I've found myself wanting to write in a *.Utils module and thinking they really belonged here. They generalize `Dict.insert`, `Dict.fromList`, and `Dict.Extra.fromListBy` respectively, but take an additional argument: a function to combine values found under identical keys and return the value to be inserted.